### PR TITLE
Silence CURl output

### DIFF
--- a/00-util.pl
+++ b/00-util.pl
@@ -26,5 +26,5 @@ make_executable(Path) :-
     bash(Cmd).
 
 curl(Source, Dest) :-
-    join(['curl -o ', Dest, ' ', Source], Cmd),
+    join(['curl -s -o ', Dest, ' ', Source], Cmd),
     bash(Cmd).


### PR DESCRIPTION
Just a tiny improvement. I find it useful, but I am considering silence other outputs (like brew and git), too. I hope you find it useful too.
