### PR TITLE
Exclude __hidden packages in Missing Packages scan

### DIFF
--- a/marelle.pl
+++ b/marelle.pl
@@ -183,7 +183,8 @@ scan_packages(Visibility) :-
     ( Visibility = all ->
         Ps = Ps1
     ; Visibility = missing ->
-        include(ismissing_ann, Ps1, Ps)
+        include(ismissing_ann, Ps1, Ps2),
+        exclude(ishidden_ann, Ps2, Ps)
     ;
         exclude(ishidden_ann, Ps1, Ps)
     ),


### PR DESCRIPTION
During `scan --missing` we should see a missing, not met, packages, but we don't want to see `--all` packages, including __hidden (virtual) packages. So, I fixed it. I hope I understand the `scan` logic correctly.
