### PR TITLE
If `~/.bash_profile` doesn't exist, look for `~/.profile` for setting the path to the `marelle` command

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -85,8 +85,13 @@ EOF
 
 function put_marelle_in_path() {
   echo 'Checking if marelle is in PATH'
-  echo 'export PATH=~/.local/bin:$PATH' >>~/.bash_profile
-  source ~/.bash_profile
+  if [ -f ~/.bash_profile ]; then
+    echo 'export PATH=~/.local/bin:$PATH' >>~/.bash_profile
+    source ~/.bash_profile
+  elif [ -f ~/.profile ]; then
+      echo 'export PATH=~/.local/bin:$PATH' >>~/.profile
+      source ~/.profile
+  fi
   if missing_exec marelle; then
     bail "Couldn't set up marelle in PATH"
   fi


### PR DESCRIPTION
This is necessary for users define their environment using `~/.profile` instead of `~/.bash_profile` as creating from scratch a `~/.bash_profile` file will override the user `~/.profile`.
